### PR TITLE
Find avahi-common library

### DIFF
--- a/zeroconf_avahi/cmake/FindAvahi.cmake
+++ b/zeroconf_avahi/cmake/FindAvahi.cmake
@@ -10,14 +10,18 @@
 #  AVAHI_LIBRARY_DIRS
 
 find_path(AVAHI_INCLUDE_DIR avahi-common/defs.h)
-find_library(AVAHI_LIBRARY 
+find_library(AVAHI_CLIENT_LIBRARY
                   NAMES avahi-client
                   HINT ${AVAHI_LIBDIR} ${AVAHI_LIBRARY_DIRS})
-set(AVAHI_LIBRARIES ${AVAHI_LIBRARY})   
+find_library(AVAHI_COMMON_LIBRARY
+                  NAMES avahi-common
+                  HINT ${AVAHI_LIBDIR} ${AVAHI_LIBRARY_DIRS})
+set(AVAHI_LIBRARIES ${AVAHI_CLIENT_LIBRARY} ${AVAHI_COMMON_LIBRARY})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Avahi DEFAULT_MSG
-				  AVAHI_LIBRARY
+				  AVAHI_CLIENT_LIBRARY
+				  AVAHI_COMMON_LIBRARY
                                   AVAHI_INCLUDE_DIR)
-mark_as_advanced(AVAHI_INCLUDE_DIR AVAHI_LIBRARY)
+mark_as_advanced(AVAHI_INCLUDE_DIR AVAHI_CLIENT_LIBRARY AVAHI_COMMON_LIBRARY)
 
 


### PR DESCRIPTION
When building zeroconf_avahi_suite on Fedora zeroconf_avahi_demos fails. Specifically, official_browse_example and official_publish_example need to link against avahi-common. FindAvahi.cmake seemed like the appropriate place to search for the library. I've tested this change on both Fedora 18 and Ubuntu 12.04 and avahi-common is found and everything compiles and links correctly on both.
