### PR TITLE
address gcc6 build error

### DIFF
--- a/zeroconf_avahi/CMakeLists.txt
+++ b/zeroconf_avahi/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(
   CATKIN_DEPENDS rosconsole roscpp zeroconf_msgs 
   DEPENDS Boost
 )
-include_directories(SYSTEM include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDES} ${AVAHI_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDES} ${AVAHI_INCLUDE_DIR})
 
 ##############################################################################
 # Project

--- a/zeroconf_avahi_demos/CMakeLists.txt
+++ b/zeroconf_avahi_demos/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS zeroconf_avahi zeroconf_msgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${zeroconf_avahi_DIR})
 find_package(Avahi REQUIRED)
 catkin_package()
-include_directories(SYSTEM include ${catkin_INCLUDE_DIRS} ${AVAHI_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS} ${AVAHI_INCLUDE_DIR})
 
 ##############################################################################
 # Project


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`, as including '-isystem /usr/include' breaks with gcc6, cf., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in the same way it was addressed in various other ROS packages. A list of related commits and pull requests is at https://github.com/ros/rosdistro/issues/12783.

The SYSTEM attribute for the include directories was added in commit 188f8fe9 on 2012-11-10 when the packages were changed to use catkin as build system. The exact reason for using the SYSTEM attribute cannot be inferred from that commit.